### PR TITLE
Watch() method typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ $scope.$watch('items', function(items){
 or
 
 ```JavaScript
-$scope.watch('items[0]', function(){
+$scope.$watch('items[0]', function(){
    // item0 changed
 }, true);
 ```
@@ -166,7 +166,7 @@ $scope.watch('items[0]', function(){
 or
 
 ```JavaScript
-$scope.watch('items[0].sizeX', function(){
+$scope.$watch('items[0].sizeX', function(){
    // item0 sizeX changed
 }, true);
 ```


### PR DESCRIPTION
Get an error when copy pasting $scope.$watch() method
