### PR TITLE
Fix #75: Do not float items up at load time.

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -651,7 +651,10 @@ angular.module('gridster', [])
 	 */
 	this.setPosition = function(row, column) {
 		this.gridster.putItem(this, row, column);
-		this.gridster.floatItemsUp();
+		if (this.gridster.$element.hasClass('gridster-loaded')) {
+			this.gridster.floatItemsUp();
+		}
+
 		this.gridster.updateHeight(this.dragging ? this.sizeY : 0);
 
 		if (this.dragging) {


### PR DESCRIPTION
I'm taking a stab at issue #75 that I filed.

Floating items up at load time caused the following issues with rendering/retaining item positions:

1) Items that were positioned below get pushed to the top and if an item that was positioned at the top was added later, it would be pushed down.
2) Causes positioning of items rendered to be dependent on the order of items in configuration array - which is weird/unintuitive.
