### PR TITLE
Fix digest already in progress errors

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -578,7 +578,9 @@ angular.module('gridster', [])
 
 					function onResize() {
 						resize();
-						scope.$apply();
+						$timeout(function(){
+							scope.$apply();	
+						});
 					}
 					if (typeof $elem.resize === 'function') {
 						$elem.resize(onResize);


### PR DESCRIPTION
The best solution here seems to be a timeout to ensure that it’s
respected in the digest and doesn’t produce “digest is already in
progress” errors.  Referenced here:
http://stackoverflow.com/questions/22346990/why-is-using-ifscope-phase-s
cope-apply-an-anti-pattern
