### PR TITLE
Use git protocol instead of https for bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
 		"angular": ">= 1.2.0",
 		"jquery": "*",
 		"jquery-ui": "*",
-		"javascript-detect-element-resize": "https://github.com/sdecima/javascript-detect-element-resize.git#~0.5.1"
+		"javascript-detect-element-resize": "git://github.com/sdecima/javascript-detect-element-resize.git#~0.5.1"
 	},
 	"devDependencies": {
 		"angular-mocks": ">= 1.2.0",


### PR DESCRIPTION
Using the https protocol has caused some SSL issues with Bower:

```
Additional error details:
error: SSL certificate problem, verify that the CA cert is OK. Details:
error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed while accessing https://github.com/sdecima/javascript-detect-element-resize.git/info/refs?service=git-upload-pack
fatal: HTTP request failed
```
