### PR TITLE
Fetch javascript-detect-element-resize from .tar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
 		"angular": ">= 1.2.0",
 		"jquery": "*",
 		"jquery-ui": "*",
-		"javascript-detect-element-resize": "https://github.com/sdecima/javascript-detect-element-resize.git#~0.5.1"
+		"javascript-detect-element-resize": "sdecima/javascript-detect-element-resize#~0.5.1"
 	},
 	"devDependencies": {
 		"angular-mocks": ">= 1.2.0",


### PR DESCRIPTION
This should allow installing angular-gridster on hosts without git, or where
bower and git don't play nice together.
