### PR TITLE
Point main property at src/angular-gridster.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
 	"name": "angular-gridster",
 	"version": "0.9.9",
-	"main": "app/scripts/gridster.js",
+	"main": "src/angular-gridster.js",
 	"dependencies": {
 		"angular": ">= 1.2.0",
 		"jquery": "*",


### PR DESCRIPTION
The main property in angular-gridster's bower.json doesn't point at a real file (there's no app/scripts folder), this points it at src/angular-gridster, as the general Bower convention is not to point at minified versions by default.

I need this so that I can use the main property to automatically include script tags in my index.html based on my dependencies' bower.json files.
