### PR TITLE
Allow for overridable mobile gridster item height via css

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -713,7 +713,7 @@ angular.module('gridster', [])
 	 */
 	this.setElementSizeY = function() {
 		if (this.gridster.isMobile) {
-			this.$element.css('height', 'auto');
+			this.$element.css('height', '');
 		} else {
 			this.$element.css('height', this.sizeY * this.gridster.curRowHeight - this.gridster.margins[0]);
 		}

--- a/src/angular-gridster.less
+++ b/src/angular-gridster.less
@@ -62,6 +62,7 @@
 }
 
 .gridster-mobile .gridster-item {
+	height: auto;
 	position: static;
 	float: none;
 }


### PR DESCRIPTION
Currently angular-gridster's mobile view set its height to 'auto' via an inline style. This is not always suitable. Hence, it's not possible to set say a fixed height for the gridster-item via css.

I considered two approaches and approach 2 was followed:
1. Add an option called mobileRowHeight and set a height based on that. But if we end up adding a config option for every change that users require, it may bloat the library with innumerable config options.
2. Remove the inline style, add the default of auto in the less file and override it to a fixed height in the user css file.
