### PR TITLE
Don't allow to place items that exceed maxRows

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -97,7 +97,7 @@ angular.module('gridster', [])
 		 * @returns {boolean} True if if item fits
 		 */
 		this.canItemOccupy = function(item, row, column) {
-			return row > -1 && column > -1 && item.sizeX + column <= this.columns;
+			return row > -1 && column > -1 && item.sizeX + column <= this.columns && item.sizeY + row <= this.maxRows;
 		};
 
 		/**
@@ -233,7 +233,7 @@ angular.module('gridster', [])
 			}
 			if (!this.canItemOccupy(item, row, column)) {
 				column = Math.min(this.columns - item.sizeX, Math.max(0, column));
-				row = Math.max(0, row);
+				row = Math.min(this.maxRows - item.sizeY, Math.max(0, row));
 			}
 
 			if (item && item.oldRow !== null && typeof item.oldRow !== 'undefined') {


### PR DESCRIPTION
Hi,

Thanks for the awesome library.

I'm looking for a way to limit the rows in which the items can be placed.
It works horizontally (limit is set with the `columns` variable) but not vertically (`maxRows` is ignored and I can place the item on any row I choose).

In this pull request I've added a quick check for vertical placing just like the horizontal one has, but it seems to break when `pushing` is set to true. Before making it work with pushing I wanted to check with you:

Is there a different way to accomplish this that I'm missing?
Would you be interested in adding this functionality?
Should there be an additional setting variable that controls this functionality? Something like `limitRows`?
