### PR TITLE
add option to keep gridster item height in mobile display

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -746,7 +746,7 @@ angular.module('gridster', [])
 	 * Sets an elements height
 	 */
 	this.setElementSizeY = function() {
-		if (this.gridster.isMobile && !saveGridItemCalculatedHeightInMobile) {
+		if (this.gridster.isMobile && !this.gridster.saveGridItemCalculatedHeightInMobile) {
 			this.$element.css('height', '');
 		} else {
 			this.$element.css('height', (this.sizeY * this.gridster.curRowHeight - this.gridster.margins[0]) + 'px');


### PR DESCRIPTION
Hi :)
I use angular-gridster, and I think its great :)
But I had a problem: when using google-table visualization inside grid-item, on mobile display, the grid-item height is 0.
So I added an option 'saveGridItemCalculatedHeightInMobile' to the gridsterConfig, so people can choose to use the calculated height also in mobile display (the default value is set to use the original, defined by you, height. 'saveGridItemCalculatedHeightInMobile' needs to be set to true in order to use the calculated height).
Thanks!
