### PR TITLE
added $broadcast of 'gridster-resized'

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -621,7 +621,7 @@
 		}
 	])
 
-	.controller('GridsterItemCtrl', ["$scope", function($scope) {
+	.controller('GridsterItemCtrl', ['$scope', function($scope) {
 		this.$element = null;
 		this.gridster = null;
 		this.row = null;
@@ -775,15 +775,15 @@
 			}
 		};
 
-		this.getElementSizeX = function(){
+		this.getElementSizeX = function() {
 			return (this.sizeX * this.gridster.curColWidth - this.gridster.margins[1]);
 		};
 
-		this.getElementSizeY = function(){
+		this.getElementSizeY = function() {
 			return (this.sizeY * this.gridster.curRowHeight - this.gridster.margins[0]);
 		};
 
-		this.broadcastResized = function(){
+		this.broadcastResized = function() {
 			$scope.$broadcast('gridster-resized', [this.sizeY, this.sizeX, this.getElementSizeY(), this.getElementSizeX()]);
 		};
 	}])
@@ -1197,7 +1197,7 @@
 							if (itemResized && gridster.resizable && gridster.resizable.stop) {
 								gridster.resizable.stop(e, $el, itemOptions); // options is the item model
 							}
-							if(itemResized && gridster.resizable){
+							if (itemResized && gridster.resizable) {
 								item.broadcastResized();
 							}
 						});

--- a/test/spec/gridster-item.js
+++ b/test/spec/gridster-item.js
@@ -32,7 +32,7 @@ describe('Controller: GridsterItemCtrl', function() {
 		};
 
 		gridster = $controller('GridsterCtrl');
-		gridsterItem = $controller('GridsterItemCtrl');
+		gridsterItem = $controller('GridsterItemCtrl', {$scope: scope});
 
 		item1x1 = {
 			sizeX: 1,


### PR DESCRIPTION
fix for #84.
Sizes are reported in grid format as well as actual pixels of the item's element.
Also, added a $broadcast event of 'gridster-initialized' when an item is initially loaded, in order to report the initial size of the item. This is useful when rendering child items inside the gridster item that require absolute sizing but need to be smaller than the parent item to allow room for header / footer / nav, etc (i.e. highcharts).
