### PR TITLE
Angular 1.3: Don't refresh when grid is display: none or width: 0

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -566,7 +566,7 @@
 						function resize() {
 							var width = parseInt($elem.css('width')) || $elem.prop('offsetWidth');
 
-							if (width === prevWidth || gridster.movingItem) {
+							if (!width || width === prevWidth || gridster.movingItem) {
 								return;
 							}
 							prevWidth = width;


### PR DESCRIPTION
A very small change, for a bug which is only found when using Angular 1.3.  This prevents the grid from redrawing when the width is 0 (`display:none`).
Related to Bug #139 (but doesn't solve the bootstrap tabs issue, I'll explain...)

This is good for two reasons:
- Performance (remove unnecessary redrawing)
- Remove flicker effect

In the following examples, I simulate angular-gridster against the two latest versions of Angular (1.2.26 & 1.3.0).  A third test case shows the patched version of angular-gridster against Angular 1.3.0.

Firstly, it fixes the following issue where the Grid doesn't even render at all:
1.2.26: http://jsfiddle.net/dhajyj8j/
1.3.0: http://jsfiddle.net/boj6dc4a/
1.3.0 (gridster-patched): http://jsfiddle.net/7n71pgwy/

But, if you include jQuery and the optional `jquery.resize.js` script from javascript-detect-element-resize dependency, which tends to trigger the `resize` function more often, you get a flicker effect.  It's caused by 0 -> width -> 0 -> width resizing.  This prevents that flicker effect.

1.2.26: http://jsfiddle.net/wca5ekeb/
1.3.0: http://jsfiddle.net/07Lhtfos/
1.3.0 (gridster-patched): http://jsfiddle.net/zpwbo392/

Now, Bootstrap Tabs.  Tabs do trigger a `resize`, but the width is 0 at that point in time (even if `display: block`).  When the tab has fully displayed, `resize` doesn't seem to fire at all and the grid never seems to draw.  It would be nice to optionally defer the `resize` if you have cases like this.  But that could be a different pull request and maybe takes some discussion.
