### PR TITLE
$broadcast when item is initialized

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1396,7 +1396,7 @@
 						aspectFn(aspects[i]);
 					}
 
-					scope.$broadcast('gridster-item-intialized', [item.sizeY, item.sizeX, item.getElementSizeY(), item.getElementSizeX()]);
+					scope.$broadcast('gridster-item-initialized', [item.sizeY, item.sizeX, item.getElementSizeY(), item.getElementSizeX()]);
 
 					function positionChanged() {
 						// call setPosition so the element and gridster controller are updated

--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -796,6 +796,21 @@
 				this.$element.css('width', (this.sizeX * this.gridster.curColWidth - this.gridster.margins[1]) + 'px');
 			}
 		};
+
+		/**
+		 * Gets an element's width
+		 */
+		this.getElementSizeX = function(){
+			return (this.sizeX * this.gridster.curColWidth - this.gridster.margins[1]);
+		};
+
+		/**
+		 * Gets an element's height
+		 */
+		this.getElementSizeY = function(){
+			return (this.sizeY * this.gridster.curRowHeight - this.gridster.margins[0]);
+		};
+
 	})
 
 	.factory('GridsterDraggable', ['$document', '$timeout', '$window',
@@ -1380,6 +1395,8 @@
 					for (var i = 0, l = aspects.length; i < l; ++i) {
 						aspectFn(aspects[i]);
 					}
+
+					scope.$broadcast('gridster-item-intialized', [item.sizeY, item.sizeX, item.getElementSizeY(), item.getElementSizeX()]);
 
 					function positionChanged() {
 						// call setPosition so the element and gridster controller are updated


### PR DESCRIPTION
This is needed so we know the pixel size of the bounding box as soon as angular-gridster initializes the item (but before the size of the DOM element is set), so we can set the size of our content (i.e. a chart).

Due to relying on a $watch on item.sizeY / item.sizeX, the DOM is not updated immediately as soon as the item is initialized, so we cannot read the size of the box from the DOM right away. It would be preferred if we could fire this event *after* the size of the DOM element has been set already.