### PR TITLE
Call stop callbacks even if item did not move / change size

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1222,11 +1222,8 @@
 						item.setSizeY(item.sizeY);
 						item.setSizeX(item.sizeX > gridster.columns ? gridster.columns : item.sizeX);
 
-						var itemResized = (originalWidth !== item.sizeX || originalHeight !== item.sizeY);
-
 						scope.$apply(function() {
-							// callback only if item really changed size
-							if (itemResized && gridster.resizable && gridster.resizable.stop) {
+							if (gridster.resizable && gridster.resizable.stop) {
 								gridster.resizable.stop(e, $el, itemOptions); // options is the item model
 							}
 						});


### PR DESCRIPTION
Fixes #161. The `resizable.stop` callback was not discussed in that pull request, but I felt it deserved the same behavior.
