### PR TITLE
Replace scheme-less ressource URI's of Demo's with http-scheme URI's

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,13 @@
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width" />
 
-    <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/css/bootstrap.css" rel="stylesheet">
+    <link href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/css/bootstrap.css" rel="stylesheet">
     <link rel="stylesheet" href="dist/angular-gridster.min.css" />
     <link rel="stylesheet" href="demo/common/style.css" />
 
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.js"></script>
-    <script src="//code.angularjs.org/1.2.15/angular-route.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.10.0/ui-bootstrap-tpls.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.js"></script>
+    <script src="http://code.angularjs.org/1.2.15/angular-route.min.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.10.0/ui-bootstrap-tpls.min.js"></script>
 
     <script src="src/angular-gridster.js"></script>
 

--- a/test.html
+++ b/test.html
@@ -12,11 +12,11 @@
 	<link rel="stylesheet" href="demo/main/style.css" />
 
 <!--
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
-    <script src="//rawgit.com/sdecima/javascript-detect-element-resize/master/detect-element-resize.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+    <script src="http://rawgit.com/sdecima/javascript-detect-element-resize/master/detect-element-resize.js"></script>
 -->
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.js"></script>
 
     <script src="src/angular-gridster.js"></script>
 


### PR DESCRIPTION
The current ressource linking will only locally if a webserver on localhost is being used (as it's using the http protocol). With schme-less URI's it's not possible to test the demo's by simply _opening_ the html file in the browser. This change will make testing the demo's easier, especially when users are not familiar with local servers (apache, grunt you name it).

If this is brings some side effects I am not aware of or it is not merged for another reason, I suggest to extend the documentation on how to get the demo working (particularly getting _grunt serve_ to run)
