### PR TITLE
Moving to https... fixing broken demo from #173

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,13 @@
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width" />
 
-    <link href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/css/bootstrap.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/css/bootstrap.css" rel="stylesheet">
     <link rel="stylesheet" href="dist/angular-gridster.min.css" />
     <link rel="stylesheet" href="demo/common/style.css" />
 
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.js"></script>
-    <script src="http://code.angularjs.org/1.2.15/angular-route.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.10.0/ui-bootstrap-tpls.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.js"></script>
+    <script src="https://code.angularjs.org/1.2.15/angular-route.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.10.0/ui-bootstrap-tpls.min.js"></script>
 
     <script src="src/angular-gridster.js"></script>
 

--- a/test.html
+++ b/test.html
@@ -12,11 +12,11 @@
 	<link rel="stylesheet" href="demo/main/style.css" />
 
 <!--
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
-    <script src="http://rawgit.com/sdecima/javascript-detect-element-resize/master/detect-element-resize.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+    <script src="https://rawgit.com/sdecima/javascript-detect-element-resize/master/detect-element-resize.js"></script>
 -->
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.js"></script>
 
     <script src="src/angular-gridster.js"></script>
 


### PR DESCRIPTION
I added 'http' in #173 instead of using the scheme-less URI for the ressources. Apparently changing the scheme does have some pitfalls: 
Since the [demo](https://rawgit.com/ManifestWebDesign/angular-gridster/master/index.html) is using https, [firefox refuses to load ressources with http](https://support.mozilla.org/en-US/kb/how-does-content-isnt-secure-affect-my-safety) (unless explicitely told to allow it), therefore the page can't load the scripts which breaks the page. By using https it works both, on https and locally with `file://` (and http should be a problem either).

Sorry for that, couldn't test it, didn't expect it.
