### PR TITLE
Added newSize and newPosition arguments to callbacks for stop events' handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ Simply pass your desired options to the gridster directive
 		   handles: ['n', 'e', 's', 'w', 'ne', 'se', 'sw', 'nw'],
 		   start: function(event, $element, widget) {}, // optional callback fired when resize is started,
 		   resize: function(event, $element, widget) {}, // optional callback fired when item is resized,
-		   stop: function(event, $element, widget) {} // optional callback fired when item is finished resizing
+		   stop: function(event, $element, widget, newSize) {} // optional callback fired when item is finished resizing
 		},
 		draggable: {
 		   enabled: true, // whether dragging items is supported
 		   handle: '.my-class', // optional selector for resize handle
 		   start: function(event, $element, widget) {}, // optional callback fired when drag is started,
 		   drag: function(event, $element, widget) {}, // optional callback fired when item is moved,
-		   stop: function(event, $element, widget) {} // optional callback fired when item is finished dragging
+		   stop: function(event, $element, widget, newPosition) {} // optional callback fired when item is finished dragging
 		}
     };
 ```

--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1017,7 +1017,7 @@
 
 					scope.$apply(function() {
 						if (gridster.draggable && gridster.draggable.stop) {
-							gridster.draggable.stop(event, $el, itemOptions);
+							gridster.draggable.stop(event, $el, itemOptions, [row, col]);
 						}
 					});
 				}
@@ -1269,6 +1269,11 @@
 					}
 
 					function resizeStop(e) {
+						var newSize = {
+							x: item.sizeX,
+							y: item.sizeY
+						};
+
 						$el.removeClass('gridster-item-moving');
 
 						gridster.movingItem = null;
@@ -1279,7 +1284,7 @@
 
 						scope.$apply(function() {
 							if (gridster.resizable && gridster.resizable.stop) {
-								gridster.resizable.stop(e, $el, itemOptions); // options is the item model
+								gridster.resizable.stop(e, $el, itemOptions, newSize); // options is the item model
 							}
 						});
 					}


### PR DESCRIPTION
Sometimes there is no way to get the actual new size or position of widget in arguments that you can find in the stop callbacks. I faced this problem today and also found an issue raised by another developer (#185) so I've added them as 4th argument in resizable.stop and draggable.stop callbacks calls.

Current change will not break existing applications.

Here are two screenshots that can probably describe situation better:
- https://dl.dropboxusercontent.com/u/106703/gridster/screen1.png
- https://dl.dropboxusercontent.com/u/106703/gridster/screen2.png
