### PR TITLE
Add unified input

### DIFF
--- a/src/angular-gridster.less
+++ b/src/angular-gridster.less
@@ -88,6 +88,8 @@
 
 .handle-se {
 	cursor: se-resize;
+	width: 12px;
+	height: 12px;
 	right: 1px;
 	bottom: 1px;
 }


### PR DESCRIPTION
Found a nice example to get all inputs (mouse, touch and pointer) within one event handler 
and adapted that into gridster.
Tested on surface (IE11 + Chrome) with mouse and touch, iPad and WP8.1.

Resizing is a bit difficult, especially on Phones and IE11.

Would be nice, if someone could test that with an Android tablet.
