### PR TITLE
Improve performance while switching item arrays

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1066,7 +1066,7 @@
 
 			value = Math.max(Math.min(value, max), min);
 
-			var changed = !(this[camelCase] === value && this['old' + titleCase] && this['old' + titleCase] === value);
+			var changed = (this[camelCase] !== value || (this['old' + titleCase] && this['old' + titleCase] !== value));
 			this['old' + titleCase] = this[camelCase] = value;
 
 			if (!this.isMoving()) {


### PR DESCRIPTION
Found some bits of performance while searching for the item vertical swapping issue.
With that changes the move/float will only be called once per sizeChanged watch giving about 15% - 20%
less while loading the main sample. On bigger grids, it will be even more.

In addition to that, the setSizeX/Y where called on positionChanged. Removing them did not change the behavior of the samples.
Any reason that these calls were in positionChanged?
