### PR TITLE
Problem with height of container gridster in IE9

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -980,6 +980,7 @@
 		this.maxSizeY = null;
 
 		this.init = function($element, gridster) {
+			gridster.grid = [];
 			this.$element = $element;
 			this.gridster = gridster;
 			this.sizeX = gridster.defaultSizeX;


### PR DESCRIPTION
If you try this example on IE9:

https://rawgit.com/ManifestWebDesign/angular-gridster/master/index.html#/dashboard

He remembers the lines of the previous screen.
To this solution is to empty the array of items in the init function.

Bye