### PR TITLE
Final Fix - Problem with height of container gridster in IE9

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1839,6 +1839,10 @@
 					var gridster = controllers[0],
 						item = controllers[1];
 
+					//fix IE > 9
+					gridster.grid = [];
+					gridster.gridHeight = 0;
+
 					// bind the item's position properties
 					if (optionsKey) {
 						var $optionsGetter = $parse(optionsKey);


### PR DESCRIPTION
If you try this example on IE9:

https://rawgit.com/ManifestWebDesign/angular-gridster/master/index.html#/dashboard

He remembers the lines of the previous screen.
This fix resolve.

By