### PR TITLE
Working with non responsive content

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -913,7 +913,14 @@
 							}
 
 							if (gridster.colWidth === 'auto') {
-								gridster.curColWidth = (gridster.curWidth + (gridster.outerMargin ? -gridster.margins[1] : gridster.margins[1])) / gridster.columns;
+
+								if ($elem[0].offsetWidth > gridster.mobileBreakPoint){
+
+									gridster.curColWidth = ($elem[0].offsetWidth + (gridster.outerMargin ? -gridster.margins[1] : gridster.margins[1])) / gridster.columns;
+								} else {
+									gridster.curColWidth = $elem[0].offsetWidth + (gridster.outerMargin ? -gridster.margins[1] : gridster.margins[1]) ; 
+								}
+
 							} else {
 								gridster.curColWidth = gridster.colWidth;
 							}
@@ -992,7 +999,21 @@
 								$elem.addClass('gridster-loaded');
 							}
 
-							scope.$parent.$broadcast('gridster-resized', [width, $elem.offsetHeight]);
+							scope.$parent.$broadcast('gridster-resized', [width, $elem[0].offsetHeight]);
+							
+							//items resize
+							for (var rowIndex = 0, l = gridster.grid.length; rowIndex < l; ++rowIndex) {
+								var columns = gridster.grid[rowIndex];
+								if (!columns) {
+									continue;
+								}
+								for (var colIndex = 0, len = columns.length; colIndex < len; ++colIndex) {
+									if (columns[colIndex]) {
+										var item = columns[colIndex];
+										scope.$broadcast('gridster-item-resized', item.row, item.col, [item.sizeY, item.sizeX, item.getElementSizeY(), item.getElementSizeX()]);
+									}
+								}
+							}
 						}
 
 						// track element width changes any way we can
@@ -1208,7 +1229,8 @@
 		 * Gets an element's width
 		 */
 		this.getElementSizeX = function() {
-			return (this.sizeX * this.gridster.curColWidth - this.gridster.margins[1]);
+			var sizeX = this.gridster.isMobile ? 1 : this.sizeX;
+			return (sizeX * this.gridster.curColWidth - this.gridster.margins[1]);
 		};
 
 		/**
@@ -1242,6 +1264,7 @@
 				var inputTags = ['select', 'input', 'textarea', 'button'];
 
 				function mouseDown(e) {
+
 					if (inputTags.indexOf(e.target.nodeName.toLowerCase()) !== -1) {
 						return false;
 					}


### PR DESCRIPTION
Trying with Google charts I can not view the content corretly when moving to mobile screen size. Google charts needs to be informed with the height and width to render the chart.

This fix is to work with fixed content.

First I changed how to calculate gridster.curColWidth when changed for mobile screen.

Second I implemented a new $broadcast called gridster-item-resized to inform custon controller with dimensions of the resized item. 

This browdcast will notify all widget instances. So I am sending row and col position and,  inside the custon controller,  we can filter the widget correctly : 

```javascript
    $scope.$on('gridster-item-resized', function (event, row, col, newSizes) {
      if ($scope.widget.row === row && $scope.widget.col === col) {
            ...
      }
    });
}
```