### PR TITLE
take care of item minSize while resizing

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1548,10 +1548,10 @@
 					minLeft = 0;
 
 				var getMinHeight = function() {
-					return gridster.curRowHeight - gridster.margins[0];
+					return (item.minSizeY ? item.minSizeY : 1) * gridster.curRowHeight - gridster.margins[0];
 				};
 				var getMinWidth = function() {
-					return gridster.curColWidth - gridster.margins[1];
+					return (item.minSizeX ? item.minSizeX : 1) * gridster.curColWidth - gridster.margins[1];
 				};
 
 				var originalWidth, originalHeight;


### PR DESCRIPTION
Forces widget resizing to fit item custom minSize, instead of gridster minSize.
Follows the original gridster behavior shown by item 9 it this demo http://gridster.net/demos/resize-limits.html