### PR TITLE
Fixes to issue https://github.com/ManifestWebDesign/angular-gridster/iss...

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -20,6 +20,7 @@
 		minColumns: 1, // minimum amount of columns the grid can scale down to
 		minRows: 1, // minimum amount of rows to show if the grid is empty
 		maxRows: 100, // maximum amount of rows in the grid
+        fixRows: false, //optional Boolean to set fixed amount of rows
 		defaultSizeX: 2, // default width of an item in columns
 		defaultSizeY: 1, // default height of an item in rows
 		minSizeX: 1, // minimum column width of an item
@@ -498,6 +499,10 @@
 			 */
 			this.updateHeight = function(plus) {
 				var maxHeight = this.minRows;
+			    if (this.fixRows) {
+		            this.gridHeight = this.maxRows;
+		            return;
+	            }
 				plus = plus || 0;
 				for (var rowIndex = this.grid.length; rowIndex >= 0; --rowIndex) {
 					var columns = this.grid[rowIndex];
@@ -510,7 +515,10 @@
 						}
 					}
 				}
-				this.gridHeight = this.maxRows - maxHeight > 0 ? Math.min(this.maxRows, maxHeight) : Math.max(this.maxRows, maxHeight);
+			    var newHeight = this.maxRows - maxHeight > 0 ? Math.min(this.maxRows, maxHeight) : Math.max(this.maxRows, maxHeight);
+			    if(newHeight>this.maxRows)
+				    newHeight=this.maxRows;
+				this.gridHeight = newHeight;
 			};
 
 			/**
@@ -527,6 +535,22 @@
 				}
 
 				return Math.round(pixels / this.curRowHeight);
+			};
+
+		    /**
+			 * Returns the number of pixels that will fit in given amount of rows
+			 *
+			 * @param {Number} rows
+			 * @param {Boolean} ceilOrFloor (Optional) Determines rounding method
+			 */
+			this.rowsToPixels = function (rows, ceilOrFloor) {
+			    if (ceilOrFloor === true) {
+			        return Math.ceil(rows * this.curRowHeight);
+			    } else if (ceilOrFloor === false) {
+			        return Math.floor(rows + this.curRowHeight);
+			    }
+
+			    return Math.round(rows * this.curRowHeight);
 			};
 
 			/**
@@ -612,7 +636,16 @@
 							// resolve "auto" & "match" values
 							if (gridster.width === 'auto') {
 								gridster.curWidth = $elem[0].offsetWidth || parseInt($elem.css('width'), 10);
-							} else {
+							}
+							else if (gridster.width === 'match') {
+							    if(gridster.colWidth === 'auto'){
+							        gridster.curWidth = $elem[0].offsetWidth || parseInt($elem.css('width'), 10);
+							    }
+							    else {
+							        gridster.curWidth = gridster.colWidth * gridster.columns +(gridster.outerMargin ? +gridster.margins[1] : gridster.margins[1]);
+							    }
+							}
+							else {
 								gridster.curWidth = gridster.width;
 							}
 
@@ -700,10 +733,18 @@
 						function updateHeight() {
 							$elem.css('height', (gridster.gridHeight * gridster.curRowHeight) + (gridster.outerMargin ? gridster.margins[0] : -gridster.margins[0]) + 'px');
 						}
-
-						scope.$watch(function() {
-							return gridster.gridHeight;
+						scope.$watch(function () {
+						    return gridster.gridHeight;
 						}, updateHeight);
+
+						function updateWidth() {
+						    if (gridster.width === 'match') {
+						        $elem.css('width', (gridster.curWidth + 'px'));
+						    }
+						}
+						scope.$watch(function () {
+						    return gridster.curWidth;
+						}, updateWidth);
 
 						scope.$watch(function() {
 							return gridster.movingItem;
@@ -1356,6 +1397,9 @@
 					}
 
 					var maxLeft = gridster.curWidth - 1;
+					if (gridster.maxRows != null) {
+					    maxTop = gridster.rowsToPixels(gridster.maxRows)+(gridster.outerMargin ? +gridster.margins[0] : gridster.margins[0])-2;
+					}
 
 					// Get the current mouse position.
 					mouseX = e.pageX;


### PR DESCRIPTION
Fixes for the issues seen in 
https://github.com/ManifestWebDesign/angular-gridster/issues/236
Some additional functionalities are created.

I introduced a new configuration Option "fixRows" which is a Boolean. If set to true, the height of the gridster is not dynamically set to how many rows are used right now, but rather set to a fixed height of the parameter maxRows.
This parameter is checked in the updateHeight function.

Furthermore the updateHeight function had a bug where it increased the size of gridster dynamically even above the limit of the maxRows. 
This has been fixed with a simple 
                           if(newHeight>this.maxRows)
				    newHeight=this.maxRows;

Also I introduced the ability to set the width parameter to "match" where the gridster would fit the width automatically by calculating it using columnsWidth * columns. (If the columnsWidth is not auto).
For this reason also the lines 740-748 were needed.

Additionally the issue that items could be placed on top of other items because of a bug with maxRows has been fixed on lines 1400-1402. This is fixed by setting the maxTop parameter so that items can not be dragged outside of the gridster, just like it is accomplished on the left and top border.
For this purpose I also had to create the function rowsToPixels.
 
