### PR TITLE
Don't check for the $elem.resize function, just use window.addResizeListener

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -744,9 +744,7 @@
 
 
 						// see https://github.com/sdecima/javascript-detect-element-resize
-						if (typeof $elem.resize === 'function') {
-							$elem.resize(onResize);
-						} else if (typeof window.addResizeListener === 'function') {
+						if (typeof window.addResizeListener === 'function') {
 							window.addResizeListener($elem[0], onResize);
 						} else {
 							scope.$watch(function() {


### PR DESCRIPTION
Partial fix for #139.  Partial as there is still a *flicker* that needs to be fixed.

This was unfortunately hard to find.  If you have a project that uses **jQuery**, the [resize](https://api.jquery.com/resize/) function is available.  If you simply go by the `main` [scripts](https://github.com/sdecima/javascript-detect-element-resize/blob/master/bower.json#L4) of **javascript-detect-element-resize**, the `detect-element-resize.js` does not override the `resize` function like the `jquery.resize.js` one [does](https://github.com/sdecima/javascript-detect-element-resize/blob/master/jquery.resize.js#L16).

Thus you fall into [this conditional clause](https://github.com/ManifestWebDesign/angular-gridster/blob/master/src/angular-gridster.js#L747), which doesn't handle all the resize cases, such as inside **Bootstrap** tabs; initially rendering as `display: none`.

It sounds like the world's are aligning incorrectly here and the chance of this happening small... but I'm not the only one.

This change just removes that `if` check.  Both scripts append the `window.addResizeListener` function [here](https://github.com/sdecima/javascript-detect-element-resize/blob/master/detect-element-resize.js#L112) and [here](https://github.com/sdecima/javascript-detect-element-resize/blob/master/jquery.resize.js#L129), which is checked on the [next line down](https://github.com/ManifestWebDesign/angular-gridster/blob/master/src/angular-gridster.js#L749).  So either script should still work.

I created a repo for testing:
https://github.com/mtraynham/angular-gridster-151

It points at master now, but you could `bower link` in this PR to see the difference.