### PR TITLE
Make just part of a widget draggable

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1884,13 +1884,15 @@
 				var unifiedInput;
 
 				this.enable = function() {
-					if (!$dragHandle) {
+					if (!$dragHandle && itemOptions.resizable) {
 						$dragHandle = angular.element('<div class="gridster-item-resizable-handler handle-' + hClass + '"></div>');
 						$el.append($dragHandle);
 					}
 
+				if ($dragHandle) {
 					unifiedInput = new GridsterTouch($dragHandle[0], mouseDown, mouseMove, mouseUp);
 					unifiedInput.enable();
+					}
 				};
 
 				this.disable = function() {
@@ -1898,9 +1900,10 @@
 						$dragHandle.remove();
 						$dragHandle = null;
 					}
-
+				if (unifiedInput) {
 					unifiedInput.disable();
 					unifiedInput = undefined;
+					}
 				};
 
 				this.destroy = function() {

--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -50,7 +50,8 @@
 		draggable: { // options to pass to draggable handler
 			enabled: true,
 			scrollSensitivity: 20, // Distance in pixels from the edge of the viewport after which the viewport should scroll, relative to pointer
-			scrollSpeed: 15 // Speed at which the window should scroll once the mouse pointer gets within scrollSensitivity distance
+			scrollSpeed: 15, // Speed at which the window should scroll once the mouse pointer gets within scrollSensitivity distance
+			element: 'widget-draggable' // Class that draggable part of widget must have
 		}
 	})
 
@@ -1353,6 +1354,11 @@
 
 					// exit, if a resize handle was hit
 					if ($target.hasClass('gridster-item-resizable-handler')) {
+						return false;
+					}
+					
+					//checking if user clciked on widgets dragged area
+					if (gridster.draggable.element && (!(e.target.classList.contains(gridster.draggable.element) || $(e.target).parents('.' + gridster.draggable.element).length))) {
 						return false;
 					}
 

--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1884,15 +1884,13 @@
 				var unifiedInput;
 
 				this.enable = function() {
-					if (!$dragHandle && itemOptions.resizable) {
+					if (!$dragHandle) {
 						$dragHandle = angular.element('<div class="gridster-item-resizable-handler handle-' + hClass + '"></div>');
 						$el.append($dragHandle);
 					}
 
-				if ($dragHandle) {
 					unifiedInput = new GridsterTouch($dragHandle[0], mouseDown, mouseMove, mouseUp);
 					unifiedInput.enable();
-					}
 				};
 
 				this.disable = function() {
@@ -1900,10 +1898,9 @@
 						$dragHandle.remove();
 						$dragHandle = null;
 					}
-				if (unifiedInput) {
+					
 					unifiedInput.disable();
 					unifiedInput = undefined;
-					}
 				};
 
 				this.destroy = function() {


### PR DESCRIPTION
If we add a parameter 'element' to 'draggable' config parameter, then, widget will be draggable just if it is under the html which has that class. 
This is useful for example if some widgets has header and we want to enable dragging of that widget only by its header. On that way we can avoid possible conflicts when trying to drag widget and clicking inside some controls in widget.

How this works ? 
- if config draggable.element exists then, widget should have that class (value of draggable.element) somewhere in its html structure. User can than start dragging just from that html element in widget, or its child structure elements.