### PR TITLE
use published/registered version of javascript-detect-element-resize

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
 	"main": ["src/angular-gridster.js", "dist/angular-gridster.min.css"],
 	"dependencies": {
 		"angular": ">= 1.2.0",
-		"javascript-detect-element-resize": "sdecima/javascript-detect-element-resize#~0.5.1"
+		"javascript-detect-element-resize": "~0.5.1"
 	},
 	"devDependencies": {
 		"angular-mocks": ">= 1.2.0",


### PR DESCRIPTION
We have a dependency on the javascript-detect-element-resize module. It
was specified as `sdecima/javascript-detect-element-resize#~0.5.1` which
is a shortcut to directly use github and not the bower registry.

Directly pointing to github broke in some use cases like using
Artifactory mirroring. As the javascript-detect-element-resize component
is registered on the public registry, we can simply point to it by name.

This patch switches to the "normal" way to specify the dependency. It
uses the same semantic version dependency as before.