### PR TITLE
Adding an option to allow drag selectively on targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ $scope.gridsterOpts = {
 	draggable: {
 	   enabled: true, // whether dragging items is supported
 	   handle: '.my-class', // optional selector for resize handle
+     restrictToClass: 'gridster-allow-drag',  // optionally allow drag only if target element has this class
 	   start: function(event, $element, widget) {}, // optional callback fired when drag is started,
 	   drag: function(event, $element, widget) {}, // optional callback fired when item is moved,
 	   stop: function(event, $element, widget) {} // optional callback fired when item is finished dragging

--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1366,7 +1366,11 @@
 						return false;
 					}
 
-					switch (e.which) {
+           // restrict to targets having a specific class (if requested)
+           if (gridster.draggable && gridster.draggable.restrictToClass && !$target.hasClass(gridster.draggable.restrictToClass))
+             return;
+					
+           switch (e.which) {
 						case 1:
 							// left mouse button
 							break;


### PR DESCRIPTION
In many cases, when the widgets host complex elements that have their own mousedown event handlers, one needs to restrict widget dragging to the box headers for example. With this option, the user can define the class name that target elements should have to allow the widget to be draggable.