### PR TITLE
Fix maxTop bound on mouseMove

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1337,7 +1337,6 @@
 					mOffY = 0,
 
 					minTop = 0,
-					maxTop = 9999,
 					minLeft = 0,
 					realdocument = $document[0];
 
@@ -1398,7 +1397,8 @@
 					}
 
 					var maxLeft = gridster.curWidth - 1;
-
+					var maxTop = gridster.curRowHeight * gridster.maxRows - 1;
+					
 					// Get the current mouse position.
 					mouseX = e.pageX;
 					mouseY = e.pageY;


### PR DESCRIPTION
If a gridster item in last row is dragged, the drag area is limited on top, right and left but not on the bottom.
If maxRows limit is reached, this leads to a bug, that dragged item can take already occupied place (no pushing or swapping happens).
Please see the attached gif.
![animation](https://cloud.githubusercontent.com/assets/3942639/14462407/39a1b402-00c7-11e6-8b75-36dda0a5e995.gif)
This fix adds bottom limit to the gridster item drag area.