### PR TITLE
Bug fix for not being able to select an option from a select control

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1342,7 +1342,7 @@
 					realdocument = $document[0];
 
 				var originalCol, originalRow;
-				var inputTags = ['select', 'input', 'textarea', 'button'];
+				var inputTags = ['select', 'option', 'input', 'textarea', 'button'];
 
 				function mouseDown(e) {
 					if (inputTags.indexOf(e.target.nodeName.toLowerCase()) !== -1) {


### PR DESCRIPTION
When the user clicks the mouse button in a option from a select control, rather than selecting the option, the user enters the drag mode. This is happening because the inputTags array does not contain the option tag. This pull request fixes this bug.