### PR TITLE
Fixes IE11 scrolling issues.

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1134,7 +1134,7 @@
 						};
 
 						// IE pointer model
-						if (target.msSetPointerCapture) {
+						if (target.msSetPointerCapture && prevent) {
 							target.msSetPointerCapture(pointerId);
 						} else if (theEvtObj.type === 'mousedown' && numberOfKeys(lastXYById) === 1) {
 							if (useSetReleaseCapture) {
@@ -1425,7 +1425,7 @@
 
 					var maxLeft = gridster.curWidth - 1;
 					var maxTop = gridster.curRowHeight * gridster.maxRows - 1;
-					
+
 					// Get the current mouse position.
 					mouseX = e.pageX;
 					mouseY = e.pageY;


### PR DESCRIPTION
We were having an issue with gridster items not properly scrolling in IE11 and after some research was able to determine that it was due to the same issue as outlined in #295.  After some digging I was unable to locate another PR for this fix, but it appears to be generally accepted as the correct solution.

Feedback appreciated. :smile: 