### PR TITLE
doEvent : Check that prevent is true before setting pointer capture (IE)

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1183,14 +1183,16 @@
 						};
 
 						// IE pointer model
-						if (target.msSetPointerCapture && prevent) {
-							target.msSetPointerCapture(pointerId);
-						} else if (theEvtObj.type === 'mousedown' && numberOfKeys(lastXYById) === 1) {
-							if (useSetReleaseCapture) {
-								target.setCapture(true);
-							} else {
-								document.addEventListener('mousemove', doEvent, false);
-								document.addEventListener('mouseup', doEvent, false);
+						if(prevent){
+							if (target.msSetPointerCapture) {
+								target.msSetPointerCapture(pointerId);
+							} else if (theEvtObj.type === 'mousedown' && numberOfKeys(lastXYById) === 1) {
+								if (useSetReleaseCapture) {
+									target.setCapture(true);
+								} else {
+									document.addEventListener('mousemove', doEvent, false);
+									document.addEventListener('mouseup', doEvent, false);
+								}
 							}
 						}
 					} else if (theEvtObj.type.match(/move$/i)) {


### PR DESCRIPTION
Fix for #416.
For anyone still bumping into it : 
in angular-gridster.js.
this [condition](https://github.com/ManifestWebDesign/angular-gridster/blob/master/src/angular-gridster.js#L1188) does not check if prevent is true in its alternate block.
It locks down the event handling, which is then never caught by a scrollbar.
